### PR TITLE
Add JSON export feature with simplified CSV

### DIFF
--- a/main.py
+++ b/main.py
@@ -82,6 +82,7 @@ class RunnerViewerApp(QObject):
         self.main_window.json_save_as_requested.connect(self.save_as_json)
         self.main_window.base_path_change_requested.connect(self.select_base_path)
         self.main_window.export_requested.connect(self.open_export_dialog)
+        self.main_window.export_json_requested.connect(self.export_json)
         
         # Left panel signals
         self.main_window.left_panel.filter_changed.connect(self.on_filter_changed)
@@ -209,6 +210,44 @@ class RunnerViewerApp(QObject):
         
         # Show the dialog
         dialog.exec_()
+
+    def export_json(self) -> None:
+        """Export current data to a JSON file and a simplified CSV."""
+        if not self.data_manager.data:
+            QMessageBox.information(
+                self.main_window,
+                "Nenhum Dados",
+                "Não há dados carregados para exportar."
+            )
+            return
+
+        from PyQt5.QtWidgets import QFileDialog
+
+        json_path, _ = QFileDialog.getSaveFileName(
+            self.main_window,
+            "Exportar JSON",
+            filter="JSON Files (*.json)"
+        )
+
+        if not json_path:
+            return
+
+        try:
+            # Save full JSON
+            self.data_manager.save_json(json_path, backup=False)
+
+            # Export simplified CSV
+            base, _ = os.path.splitext(json_path)
+            csv_path = base + "_export.csv"
+            exported = self.data_manager.export_simplified_csv(csv_path)
+
+            QMessageBox.information(
+                self.main_window,
+                "Exportação Concluída",
+                f"JSON salvo em {json_path}\nCSV salvo em {csv_path}\n{exported} linhas exportadas."
+            )
+        except Exception as e:
+            QMessageBox.critical(self.main_window, "Erro", f"Falha ao exportar: {e}")
 
     def collect_stats(self) -> None:
         """Collect brands and categories from data (new format)."""

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -25,6 +25,7 @@ class RunnerViewerMainWindow(QMainWindow):
     base_path_change_requested = pyqtSignal()
     configuration_requested = pyqtSignal()
     export_requested = pyqtSignal()
+    export_json_requested = pyqtSignal()
     
     def __init__(self):
         super().__init__()
@@ -147,7 +148,10 @@ class RunnerViewerMainWindow(QMainWindow):
         
         set_base = QAction("📁 Definir Base Path", self)
         set_base.triggered.connect(lambda: self.base_path_change_requested.emit())
-        
+
+        export_json = QAction("📝 Exportar JSON", self)
+        export_json.triggered.connect(lambda: self.export_json_requested.emit())
+
         file_menu = self.menuBar().addMenu("Arquivo")
         if file_menu:
             file_menu.addAction(open_json)
@@ -156,6 +160,7 @@ class RunnerViewerMainWindow(QMainWindow):
             file_menu.addAction(save_as_json)
             file_menu.addSeparator()
             file_menu.addAction(set_base)
+            file_menu.addAction(export_json)
         
         # Tools menu
         config_action = QAction("⚙️ Configurações", self)


### PR DESCRIPTION
## Summary
- add a new menu action to export JSON data
- connect export signal in the application and implement handler
- provide DataManager method to export simplified CSV

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6865fa7afe708321a0dbc4cfbe4b9dd6