### PR TITLE
Add SQL backend with race manager UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ train/*
 output/*
 *.pyc
 __pycache__/*
+database.db

--- a/core/data_manager.py
+++ b/core/data_manager.py
@@ -24,6 +24,12 @@ class DataManager:
             self.data = json.load(f)
         self.cache.build_cache(self.data)
         self.undo_stack = []
+
+    def load_data(self, data: List[Dict[str, Any]]) -> None:
+        """Load data directly from a list of dictionaries."""
+        self.data = list(data)
+        self.cache.build_cache(self.data)
+        self.undo_stack = []
     
     def save_json(self, file_path: str, backup: bool = True) -> None:
         """Save data to JSON file."""

--- a/db/db_manager.py
+++ b/db/db_manager.py
@@ -1,0 +1,88 @@
+import json
+from datetime import datetime
+from typing import List, Dict, Any
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from utils.config import load_config
+from .models import Base, Race, Participant
+from core.data_manager import DataManager
+
+
+def get_engine_from_config(config_path: str):
+    cfg = load_config(config_path)
+    url = cfg.get("url", "sqlite:///database.db")
+    return create_engine(url, future=True)
+
+
+class DBManager:
+    def __init__(self, config_path: str = "db_config.yaml"):
+        self.config_path = config_path
+        self.engine = get_engine_from_config(config_path)
+        Base.metadata.create_all(self.engine)
+        self.Session = sessionmaker(bind=self.engine, future=True)
+
+    def list_races(self) -> List[Dict[str, Any]]:
+        session = self.Session()
+        races = session.query(Race).all()
+        result = []
+        for race in races:
+            participants_data = [json.loads(p.data) for p in race.participants]
+            num_participants = len(participants_data)
+            images = 0
+            categories = set()
+            for p in participants_data:
+                if p.get("run_category"):
+                    categories.add(p["run_category"])
+                for r in p.get("runners_found", []):
+                    if r.get("image") or r.get("image_path"):
+                        images += 1
+            result.append({
+                "id": race.id,
+                "name": race.name,
+                "date": race.date.isoformat() if race.date else "",
+                "location": race.location,
+                "num_participants": num_participants,
+                "num_images": images,
+                "categories": ", ".join(sorted(categories))
+            })
+        session.close()
+        return result
+
+    def add_race(self, name: str, location: str, date: datetime.date, json_path: str) -> int:
+        session = self.Session()
+        with open(json_path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        race = Race(name=name, location=location, date=date)
+        session.add(race)
+        session.flush()
+        for item in data:
+            session.add(Participant(race_id=race.id, data=json.dumps(item)))
+        session.commit()
+        session.close()
+        return race.id
+
+    def delete_race(self, race_id: int) -> None:
+        session = self.Session()
+        race = session.get(Race, race_id)
+        if race:
+            session.delete(race)
+            session.commit()
+        session.close()
+
+    def load_race_data(self, race_id: int) -> List[Dict[str, Any]]:
+        session = self.Session()
+        race = session.get(Race, race_id)
+        data = [json.loads(p.data) for p in race.participants] if race else []
+        session.close()
+        return data
+
+    def export_race_to_json(self, race_id: int, path: str) -> None:
+        data = self.load_race_data(race_id)
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(data, f, ensure_ascii=False, indent=2)
+
+    def export_race_to_csv(self, race_id: int, path: str) -> int:
+        data = self.load_race_data(race_id)
+        dm = DataManager()
+        dm.load_data(data)
+        return dm.export_simplified_csv(path)

--- a/db/models.py
+++ b/db/models.py
@@ -1,0 +1,25 @@
+from sqlalchemy.orm import declarative_base, relationship
+from sqlalchemy import Column, Integer, String, Date, DateTime, ForeignKey, Text
+import datetime
+
+Base = declarative_base()
+
+class Race(Base):
+    __tablename__ = "races"
+
+    id = Column(Integer, primary_key=True)
+    name = Column(String, nullable=False)
+    location = Column(String)
+    date = Column(Date)
+    created_at = Column(DateTime, default=datetime.datetime.utcnow)
+
+    participants = relationship("Participant", back_populates="race", cascade="all, delete-orphan")
+
+class Participant(Base):
+    __tablename__ = "participants"
+
+    id = Column(Integer, primary_key=True)
+    race_id = Column(Integer, ForeignKey("races.id"), nullable=False)
+    data = Column(Text)  # JSON string
+
+    race = relationship("Race", back_populates="participants")

--- a/db_config.yaml
+++ b/db_config.yaml
@@ -1,0 +1,1 @@
+url: sqlite:///database.db

--- a/main.py
+++ b/main.py
@@ -14,6 +14,8 @@ from ui.tree_widget import TreeManager
 from ui.image_display import ImageDisplayManager
 from ui.image_display import ExportManager
 from ui.export_dialog import ExportDialog
+from ui.race_manager import RaceManagerWindow
+from db.db_manager import DBManager
 from core.data_manager import DataManager
 from utils.config import load_config, save_config
 from utils.image_utils import clear_image_cache
@@ -1435,14 +1437,23 @@ class RunnerViewerApp(QObject):
         return sorted(brands), sorted(cats), sorted(genders)
 
 def main():
-    """Main entry point for the application."""
+    """Main entry point for the application with SQL support."""
     app = QApplication(sys.argv)
-    
-    # Create and show the application
+
+    dbm = DBManager()
+    race_window = RaceManagerWindow(dbm)
     viewer = RunnerViewerApp()
-    viewer.show()
-    
-    # Start the event loop
+
+    def open_race(race_id: int) -> None:
+        data = dbm.load_race_data(race_id)
+        viewer.data_manager.load_data(data)
+        viewer.collect_stats()
+        viewer.populate_tree()
+        viewer.show()
+
+    race_window.race_selected.connect(open_race)
+    race_window.show()
+
     sys.exit(app.exec_())
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
 PyQt5
 PyYAML
 Pillow
+SQLAlchemy
+psycopg2-binary
 

--- a/ui/race_manager.py
+++ b/ui/race_manager.py
@@ -1,0 +1,142 @@
+from typing import List
+from datetime import datetime
+from PyQt5.QtCore import Qt, pyqtSignal
+from PyQt5.QtWidgets import (
+    QWidget, QVBoxLayout, QHBoxLayout, QTableWidget, QTableWidgetItem,
+    QPushButton, QFileDialog, QLineEdit, QLabel, QDateEdit
+)
+
+from db.db_manager import DBManager
+
+
+class RaceManagerWindow(QWidget):
+    race_selected = pyqtSignal(int)
+
+    def __init__(self, db_manager: DBManager):
+        super().__init__()
+        self.db = db_manager
+        self.setWindowTitle("Bases Importadas")
+        self.resize(600, 400)
+        self._setup_ui()
+        self.refresh()
+
+    def _setup_ui(self) -> None:
+        layout = QVBoxLayout(self)
+
+        self.table = QTableWidget()
+        self.table.setColumnCount(5)
+        self.table.setHorizontalHeaderLabels([
+            "Nome", "Data", "Corredores", "Imagens", "Categorias"
+        ])
+        self.table.cellDoubleClicked.connect(self._open_selected)
+        layout.addWidget(self.table)
+
+        btn_row = QHBoxLayout()
+        self.delete_btn = QPushButton("Deletar")
+        self.delete_btn.clicked.connect(self._delete_selected)
+        btn_row.addWidget(self.delete_btn)
+
+        self.export_json_btn = QPushButton("Exportar JSON")
+        self.export_json_btn.clicked.connect(self._export_json)
+        btn_row.addWidget(self.export_json_btn)
+
+        self.export_csv_btn = QPushButton("Exportar CSV")
+        self.export_csv_btn.clicked.connect(self._export_csv)
+        btn_row.addWidget(self.export_csv_btn)
+
+        layout.addLayout(btn_row)
+
+        # Add new race section
+        form_row = QHBoxLayout()
+        self.name_edit = QLineEdit()
+        self.name_edit.setPlaceholderText("Nome da Prova")
+        form_row.addWidget(self.name_edit)
+
+        self.loc_edit = QLineEdit()
+        self.loc_edit.setPlaceholderText("Local")
+        form_row.addWidget(self.loc_edit)
+
+        self.date_edit = QDateEdit()
+        self.date_edit.setCalendarPopup(True)
+        self.date_edit.setDate(datetime.now())
+        form_row.addWidget(self.date_edit)
+
+        self.json_path = QLineEdit()
+        self.json_path.setPlaceholderText("JSON...")
+        form_row.addWidget(self.json_path)
+        browse = QPushButton("Selecionar")
+        browse.clicked.connect(self._select_json)
+        form_row.addWidget(browse)
+
+        add_btn = QPushButton("Adicionar")
+        add_btn.clicked.connect(self._add_race)
+        form_row.addWidget(add_btn)
+
+        layout.addLayout(form_row)
+
+    def refresh(self) -> None:
+        races = self.db.list_races()
+        self.table.setRowCount(len(races))
+        for row, race in enumerate(races):
+            self.table.setItem(row, 0, QTableWidgetItem(race["name"]))
+            self.table.setItem(row, 1, QTableWidgetItem(race["date"]))
+            self.table.setItem(row, 2, QTableWidgetItem(str(race["num_participants"])))
+            self.table.setItem(row, 3, QTableWidgetItem(str(race["num_images"])))
+            self.table.setItem(row, 4, QTableWidgetItem(race["categories"]))
+            # store id in row data
+            self.table.setRowHeight(row, 20)
+            self.table.item(row,0).setData(Qt.UserRole, race["id"])
+
+    def _selected_race_id(self) -> int:
+        row = self.table.currentRow()
+        if row < 0:
+            return -1
+        item = self.table.item(row, 0)
+        return item.data(Qt.UserRole)
+
+    def _delete_selected(self) -> None:
+        rid = self._selected_race_id()
+        if rid is None or rid == -1:
+            return
+        self.db.delete_race(rid)
+        self.refresh()
+
+    def _open_selected(self, row: int, column: int) -> None:
+        item = self.table.item(row, 0)
+        rid = item.data(Qt.UserRole)
+        if rid:
+            self.race_selected.emit(rid)
+
+    def _export_json(self) -> None:
+        rid = self._selected_race_id()
+        if rid == -1:
+            return
+        path, _ = QFileDialog.getSaveFileName(self, "Exportar JSON", filter="JSON (*.json)")
+        if path:
+            self.db.export_race_to_json(rid, path)
+
+    def _export_csv(self) -> None:
+        rid = self._selected_race_id()
+        if rid == -1:
+            return
+        path, _ = QFileDialog.getSaveFileName(self, "Exportar CSV", filter="CSV (*.csv)")
+        if path:
+            self.db.export_race_to_csv(rid, path)
+
+    def _select_json(self) -> None:
+        path, _ = QFileDialog.getOpenFileName(self, "JSON", filter="JSON (*.json)")
+        if path:
+            self.json_path.setText(path)
+
+    def _add_race(self) -> None:
+        path = self.json_path.text()
+        if not path:
+            return
+        name = self.name_edit.text() or "Prova"
+        location = self.loc_edit.text()
+        date = self.date_edit.date().toPyDate()
+        self.db.add_race(name, location, date, path)
+        self.name_edit.clear()
+        self.loc_edit.clear()
+        self.json_path.clear()
+        self.refresh()


### PR DESCRIPTION
## Summary
- introduce SQLAlchemy models and DB manager
- add race manager window to manage race data
- load application data from SQL instead of JSON
- support configuration via `db_config.yaml`
- update requirements for SQL packages

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686602af50688321b89a8bde75308adc